### PR TITLE
Add Plug Mini

### DIFF
--- a/lib/switchbot.rb
+++ b/lib/switchbot.rb
@@ -15,6 +15,7 @@ require_relative 'switchbot/light'
 require_relative 'switchbot/humidifier'
 require_relative 'switchbot/color_bulb'
 require_relative 'switchbot/lock'
+require_relative 'switchbot/plug_mini'
 
 module Switchbot
   class Error < StandardError; end

--- a/lib/switchbot/client.rb
+++ b/lib/switchbot/client.rb
@@ -78,6 +78,10 @@ module Switchbot
       Lock.new(client: self, device_id: device_id)
     end
 
+    def plug_mini(device_id)
+      PlugMini.new(client: self, device_id: device_id)
+    end
+
     private
 
     def headers

--- a/lib/switchbot/plug_mini.rb
+++ b/lib/switchbot/plug_mini.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Switchbot
+  class PlugMini
+    extend Forwardable
+
+    def_delegators :@device, :status, :commands, :on, :off, :on?, :off?
+
+    def initialize(client:, device_id:)
+      @device = Device.new(client: client, device_id: device_id)
+    end
+
+    def toggle
+      commands(command: 'toggle')
+    end
+  end
+end

--- a/spec/switchbot/plug_mini_spec.rb
+++ b/spec/switchbot/plug_mini_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+RSpec.describe Switchbot::PlugMini do
+  include_context :api_variables
+
+  let(:plug_mini) { client.plug_mini(device_id) }
+  let(:device_id) { 'C271111EC0AB' }
+
+  describe '#status' do
+    subject { plug_mini.status }
+
+    before do
+      allow(Switchbot::Device).to receive_message_chain(:new, :status)
+    end
+
+    it do
+      subject
+      expect(Switchbot::Device.new).to have_received(:status)
+    end
+  end
+
+  describe '#on' do
+    subject { plug_mini.on }
+
+    before do
+      allow(Switchbot::Device).to receive_message_chain(:new, :on)
+    end
+
+    it do
+      subject
+      expect(Switchbot::Device.new).to have_received(:on)
+    end
+  end
+
+  describe '#off' do
+    subject { plug_mini.off }
+
+    before do
+      allow(Switchbot::Device).to receive_message_chain(:new, :off)
+    end
+
+    it do
+      subject
+      expect(Switchbot::Device.new).to have_received(:off)
+    end
+  end
+
+  describe '#on?' do
+    subject { plug_mini.on? }
+
+    before do
+      allow(Switchbot::Device).to receive_message_chain(:new, :on?).and_return(true)
+    end
+
+    it { is_expected.to eq true }
+  end
+
+  describe '#off?' do
+    subject { plug_mini.off? }
+
+    before do
+      allow(Switchbot::Device).to receive_message_chain(:new, :off?).and_return(true)
+    end
+
+    it { is_expected.to eq true }
+  end
+
+  describe '#toggle' do
+    subject { plug_mini.toggle }
+
+    before do
+      allow(Switchbot::Device).to receive_message_chain(:new, :commands)
+    end
+
+    it do
+      subject
+      expect(Switchbot::Device.new).to have_received(:commands).with(command: 'toggle')
+    end
+  end
+end


### PR DESCRIPTION
- Added SwitchBot Plug Mini
- I didn't separate the implementation of the module because the interfaces for Plug Mini (US) and Plug Mini (JP) were the same.

<img width="667" alt="image" src="https://user-images.githubusercontent.com/10582/226301791-35c35efc-46a4-4c5c-aae3-cd2567963b82.png">
