### PR TITLE
Allow using environment variables as default for token and secret if not specified during Switchbot::Client initialization

### DIFF
--- a/lib/switchbot/client.rb
+++ b/lib/switchbot/client.rb
@@ -4,12 +4,13 @@ module Switchbot
   class Client
     API_VERSION = 'v1.1'
 
-    def initialize(token, secret)
-      @request = Request.new(token, secret)
+    def initialize(token = nil, secret = nil)
+      @token = token || ENV.fetch('SWITCHBOT_API_TOKEN', '')
+      @secret = secret || ENV.fetch('SWITCHBOT_API_SECRET', '')
     end
 
     def devices
-      @request.get("/#{API_VERSION}/devices")
+      request.get("/#{API_VERSION}/devices")
     end
 
     def device(device_id)
@@ -17,16 +18,16 @@ module Switchbot
     end
 
     def status(device_id:)
-      @request.get("/#{API_VERSION}/devices/#{device_id}/status")
+      request.get("/#{API_VERSION}/devices/#{device_id}/status")
     end
 
     def commands(device_id:, command:, parameter: 'default', command_type: 'command')
-      @request.post("/#{API_VERSION}/devices/#{device_id}/commands",
-                    params: { command: command, parameter: parameter, commandType: command_type })
+      request.post("/#{API_VERSION}/devices/#{device_id}/commands",
+                   params: { command: command, parameter: parameter, commandType: command_type })
     end
 
     def scenes
-      @request.get("/#{API_VERSION}/scenes")
+      request.get("/#{API_VERSION}/scenes")
     end
 
     def scene(scene_id)
@@ -34,7 +35,7 @@ module Switchbot
     end
 
     def execute(scene_id:)
-      @request.post("/#{API_VERSION}/scenes/#{scene_id}/execute")
+      request.post("/#{API_VERSION}/scenes/#{scene_id}/execute")
     end
 
     def bot(device_id)
@@ -59,6 +60,12 @@ module Switchbot
 
     def plug_mini(device_id)
       PlugMini.new(client: self, device_id: device_id)
+    end
+
+    private
+
+    def request
+      @request ||= Request.new(@token, @secret)
     end
   end
 end

--- a/spec/switchbot/client_spec.rb
+++ b/spec/switchbot/client_spec.rb
@@ -3,6 +3,27 @@
 RSpec.describe Switchbot::Client do
   include_context :api_variables
 
+  describe '#initialize' do
+    context 'when token and secret are given' do
+      subject { described_class.new('api_token', 'api_secret') }
+
+      it { expect(subject.instance_variable_get(:@token)).to eq 'api_token' }
+      it { expect(subject.instance_variable_get(:@secret)).to eq 'api_secret' }
+    end
+
+    context 'when token and secret are not given' do
+      subject { described_class.new }
+
+      before do
+        ENV['SWITCHBOT_API_TOKEN'] = 'api_token'
+        ENV['SWITCHBOT_API_SECRET'] = 'api_secret'
+      end
+
+      it { expect(subject.instance_variable_get(:@token)).to eq 'api_token' }
+      it { expect(subject.instance_variable_get(:@secret)).to eq 'api_secret' }
+    end
+  end
+
   describe '#devices' do
     subject(:devices) { client.devices }
 


### PR DESCRIPTION
This pull request adds the ability to use environment variables as default values for the token and secret when they are not specified during initialization of the Switchbot::Client class.